### PR TITLE
Display "more" link under search facets to display all facet groups w…

### DIFF
--- a/src/css/advancedsearch.css
+++ b/src/css/advancedsearch.css
@@ -177,6 +177,20 @@ ol#tree > li > strong {
     font-style: italic;
 }
 
+.search-facet-expansion {
+    margin-top: 3px;
+    margin-bottom: -2px;
+}
+
+.search-facet-expansion a {
+    padding-left: 10px;
+    font-style: italic;
+}
+
+.search-facet-expansion a:visited {
+    color: rgb(0, 114, 207);
+}
+
 /* search examples */
 .searchform .search {
     padding: 5px 37px 5px 5px;

--- a/src/js/pages/advanced-search-results.js
+++ b/src/js/pages/advanced-search-results.js
@@ -254,13 +254,67 @@ function renderFacetTree(state, facets) {
                         $('<span>').html('&#9662 '),
                         document.createTextNode(facetGroup.label)
                     ),
+                $('<div>')
+                    .addClass('search-facet-expansion')
+                    .append(
+                        renderLessFacetLink(state, facetGroup)
+                    ),
                 $('<ul>')
                     .addClass('campl-unstyled-list')
                     .append(
                         facetGroup.facets.map(renderFacet.bind(undefined, state, facetGroup))
-                    )
+                    ),
+                $('<div>')
+                    .addClass('search-facet-expansion')
+                    .append(
+                        renderMoreFacetLink(state, facetGroup),
+                        renderLessFacetLink(state, facetGroup)
+                    ),
             )[0];
     }));
+}
+
+/**
+ * Display a "more" link for the facet group that will expand to
+ * display all the facets if some of them are hidden.
+ */
+function renderMoreFacetLink(state, facetGroup) {
+    let facetName = facetGroup.field;
+    let facetTotal = facetGroup.totalFacets;
+
+    if (facetGroup.facets.length < facetTotal) {
+
+        let expandState = Object.assign({}, state);
+        expandState.expandFacet = facetName;
+        let url = serialiseQuery(expandState);
+
+        return $('<a>')
+            .attr('href', url)
+            .text('more')
+            .prop('title', 'More ' + facetName + ' facets')
+    }
+}
+
+/**
+ * Display a "less" link for the facet group that will hide facets.
+ * The number of facets to display is configured in XTF.
+ */
+function renderLessFacetLink(state, facetGroup) {
+    let expandedFacet = state.expandFacet;
+    let facetName = facetGroup.field;
+
+    if (expandedFacet === facetName) {
+
+        let expandState = Object.assign({}, state);
+        expandState.expandFacet = "";
+        let url = serialiseQuery(expandState);
+
+        return $('<a>')
+            .attr('href', url)
+            .text('less')
+            .prop('title', 'Fewer ' + facetName + ' facets')
+
+    }
 }
 
 function renderSelectedFacet(state, selectedFacet) {


### PR DESCRIPTION
…hen only a selection is displayed by XTF at first. Plus corresponding "less" links for facets that are fully displayed.