### PR TITLE
Style crumbtrail and improve rendering of collection/subcollection pages

### DIFF
--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -526,6 +526,21 @@ li.campl-selected {font-weight: bold;}
     }
 }
 
+/* Page title classes */
+
+.pagetitle.campl-wrap.clearfix {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.pagetitle {
+    padding: 0 20px 0 20px;
+}
+
+.pagetitle h1 {
+    font-weight:500;
+}
+
 
 /* Carousel Classes */
 

--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -469,6 +469,67 @@ button {
     text-decoration: none;
 }
 
+/* Crumbtrail classes */
+.crumbtrail {
+    font-size: 0.9rem;
+    margin-bottom:1.25rem;
+}
+
+.crumbtrail .fa-home {font-size: 1.25rem;}
+.campl-unstyled-list {list-style:none;margin:0}
+.campl-tertiary-navigation {font-size:14px;line-height: 20px;}
+.campl-vertical-breadcrumb , .campl-vertical-breadcrumb-navigation, .campl-vertical-breadcrumb-children a{ color: #0072cf; text-decoration:none;border-bottom:0;outline: none;}
+.campl-recessed-content .campl-tertiary-navigation {margin-top:40px;padding-bottom:0px}
+.campl-tertiary-navigation {position:relative;z-index:11}
+.campl-tertiary-navigation-structure {background:#fff;border-bottom:1px solid #e4e4e4;}
+.campl-vertical-breadcrumb li {line-height:16px;position:relative;word-wrap:break-word}
+.campl-vertical-breadcrumb a {padding:16px 30px 16px 20px;background:#fafafa url(/img/interface/bg-vertical-breadcrumb-up-arrow.png) no-repeat 95% 50% ;border-bottom:1px solid #e4e4e4;display:block;position:relative;}
+.campl-vertical-breadcrumb-indicator {z-index:9;display:block;width:19px;height:10px;background:url(/img/interface/bg-vertical-breadcrumb-indicator-arrow.png) no-repeat 0 0;position:absolute;bottom:-10px;left:20px;}
+.campl-vertical-breadcrumb a:focus, .campl-vertical-breadcrumb a:hover, .campl-vertical-breadcrumb a:active {background:#efefef url(/img/interface/bg-vertical-breadcrumb-up-arrow.png) no-repeat 95% 50%;text-decoration:none}
+.campl-vertical-breadcrumb a:focus .campl-vertical-breadcrumb-indicator,
+.campl-vertical-breadcrumb a:hover .campl-vertical-breadcrumb-indicator,
+.campl-vertical-breadcrumb a:active .campl-vertical-breadcrumb-indicator {background:url(/img/interface/bg-vertical-breadcrumb-indicator-arrow-over.png) no-repeat 0 0;}
+.campl-vertical-breadcrumb-navigation {display:block;padding:5px 20px;font-weight:bold }
+.campl-vertical-breadcrumb-navigation .campl-selected > a,
+.campl-vertical-breadcrumb-navigation .campl-selected > a:focus,
+.campl-vertical-breadcrumb-navigation .campl-selected > a:hover,
+.campl-vertical-breadcrumb-navigation .campl-selected > a:visited {color:#171717;}
+.campl-vertical-breadcrumb-navigation li {padding:10px 0;border-bottom:1px solid #e4e4e4}
+.campl-vertical-breadcrumb-navigation li:last-child {border-bottom:0}
+.campl-vertical-breadcrumb-children {border-bottom:0;margin:10px 0 0; }
+.campl-vertical-breadcrumb-children li {padding:5px 5px 5px 0;border-bottom:0;font-weight:normal}
+.campl-vertical-breadcrumb-children a {border-bottom:0;background:#fff url(/img/interface/bg-vertical-breadcrumb-right-arrow.png) no-repeat 0 50% ;font-weight:normal;padding:0 0 0 15px}
+.campl-vertical-breadcrumb-children a:focus, .campl-vertical-breadcrumb-children a:hover, .campl-vertical-breadcrumb-children a:active {background:#fff url(/img/interface/bg-vertical-breadcrumb-right-arrow.png) no-repeat 0 50%; text-decoration:underline}
+.campl-vertical-breadcrumb-children .campl-selected a {cursor:default}
+.campl-vertical-breadcrumb-children .campl-selected a:focus, .campl-vertical-breadcrumb-children .campl-selected a:hover {text-decoration:none}
+.campl-tertiary-navigation {border:1px solid #e4e4e4;border-width:1px 1px 0 1px }
+.campl-vertical-breadcrumb {font-family:"Lato", sans-serif;font-weight:600;font-style:normal}
+.campl-vertical-breadcrumb-navigation {font-family:"Lato", sans-serif;font-weight:400;color:#888888}
+.campl-vertical-breadcrumb , .campl-vertical-breadcrumb-navigation, .campl-vertical-breadcrumb-children a { color: #0072cf; text-decoration:none;border-bottom:0;outline: none;}
+.campl-vertical-breadcrumb a {color:#999999}
+ul.campl-vertical-breadcrumb, ul.campl-vertical-breadcrumb, ul.campl-vertical-breadcrumb-children { padding: 0;}
+li.campl-selected {font-weight: bold;}
+
+.campl-tertiary-navigation li a {
+    display: inline-block;
+    width: 100%;
+}
+
+@media (max-width: 767px) {
+    .campl-vertical-breadcrumb {font-size:18px;line-height: 24px}
+    #crumbtrail li {margin:0 0 15px 0}
+    #crumbtrail ul {padding: 0;margin: 15px 0 9px 15px;}
+    .campl-tertiary-navigation{display:none}
+}
+
+@media print {
+    .campl-tertiary-navigation {
+        display: none !important
+    }
+}
+
+}
+
 
 /* Carousel Classes */
 

--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -528,8 +528,6 @@ li.campl-selected {font-weight: bold;}
     }
 }
 
-}
-
 
 /* Carousel Classes */
 

--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -452,10 +452,8 @@ button {
     background-color: #106470;
     color:#fff;
     margin-top: 20px;
-    margin-bottom: 20px;
-    padding-left: 12px;
-    padding-bottom: 1px;
-    padding-top: 1px;
+    margin-bottom: 0.5rem;
+    padding: 1px 0 1px 12px;
     display: flex;
 }
 

--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -452,7 +452,7 @@ button {
     background-color: #106470;
     color:#fff;
     margin-top: 20px;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
     padding: 1px 0 1px 12px;
     display: flex;
 }
@@ -470,7 +470,8 @@ button {
 /* Crumbtrail classes */
 .crumbtrail {
     font-size: 0.9rem;
-    margin-bottom:1.25rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.25rem;
 }
 
 .crumbtrail .fa-home {font-size: 1.25rem;}

--- a/src/css/project-light-legacy.css
+++ b/src/css/project-light-legacy.css
@@ -149,3 +149,13 @@
 .campl-focus-link {
     background-color: #0c5963
 }
+/* Blockquote formatting */
+
+blockquote {padding: 0 0 0 25px;margin: 18px 0;font-style:italic;background:url(/img/interface/bg-blockquote-top.png) no-repeat top left}
+blockquote p {margin-bottom: 10px;font-weight: 300;line-height: 22.5px;float:left;padding-right:25px}
+blockquote p.campl-quote-mark{background:url(/img/interface/bg-blockquote-bottom.png) no-repeat bottom right;}
+blockquote cite {display: block;line-height: 18px;color: #999999;clear:both}
+blockquote cite:before {content: '\2014 \00A0';}
+q:before,q:after,blockquote:before,blockquote:after {content: ""; content: none;}
+blockquote.campl-float-right {margin-left:20px;width:230px;margin-top:0px;}
+blockquote.campl-float-right p {padding-right:0px;background:url(/img/interface/bg-blockquote-bottom.png) no-repeat bottom right;}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -6,6 +6,7 @@
 @import "./recall-slider.css";
 @import "./column-layouts.css";
 @import "./project-light-legacy.css";
+@import "~font-awesome/css/font-awesome.css";
 
 /* homepage style */
 .carousel-panel {


### PR DESCRIPTION
The css changes largely revolve around the crumbtrail and page title changes to the cudl-viewer (see PR there). 

Some CSS changes were made to the cudl-banner definition to improve spacing issues. I also added some more missing project-light styles into project-light-legacy.css. Most were for the crumbtrail (which is replicated with the project-light css). However, some declarations were added to improve the display of the longitude, newton pages, etc. The display of those pages still isn't a good as it could be, but that's mostly the consequence of the legacy project light grid that's being replicated. Tweaking that HTML/some classes would, naturally, improve it. We could achieve the same effect with css selectors if we wrapped all imported html within a div with a consistent classname/id value.
