### PR TITLE
Avoid Chrome adding window history entries when item has no transcription/translation

### DIFF
--- a/src/js/pages/document.js
+++ b/src/js/pages/document.js
@@ -921,26 +921,33 @@ function setTranscriptionPage(data, pagenum) {
         return;
     }
 
+    let transCss = "<link href='styles/style-transcription.css' rel='stylesheet' type='text/css'/>"
+
     // diplomatic transcriptions
     var url = data.pages[pagenum-1].transcriptionDiplomaticURL;
     if (typeof url != 'undefined' && typeof data.allTranscriptionDiplomaticURL == 'undefined') {
-        document.getElementById('transcriptiondiploframe').src = context.services + url;
+        $('#transcriptiondiploframe').removeAttr('srcdoc');
+        $('#transcriptiondiploframe').attr('src', new URL(url, context.services));
     } else {
-        document.getElementById('transcriptiondiploframe').src = 'data:text/html;charset=utf-8,%3Chtml%3E%3Chead%3E%3Clink href%3D%22styles%2Fstyle-transcription.css%22 rel%3D%22stylesheet%22 type%3D%22text%2Fcss%22%2F%3E%0A%3C%2Fhead%3E%3Cbody%3E%3Cdiv class%3D%22transcription%22%3ENo transcription available for this image.%3C%2Fdiv%3E%3C%2Fbody%3E%3C%2Fhtml%3E';
+        $('#transcriptiondiploframe').contents().find('head').html(transCss);
+        $('#transcriptiondiploframe').contents().find('body').html("No transcription available for this image.");
     }
 
     // translation
     var url = data.pages[pagenum-1].translationURL;
     if (typeof url != 'undefined') {
-        document.getElementById('translationframe').src = context.services + url;
+        $('#translationframe').removeAttr('srcdoc');
+        $('#translationframe').attr('src', new URL(url, context.services));
     } else {
-        document.getElementById('translationframe').src = 'data:text/html;charset=utf-8,%3Chtml%3E%3Chead%3E%3Clink href%3D%22styles%2Fstyle-transcription.css%22 rel%3D%22stylesheet%22 type%3D%22text%2Fcss%22%2F%3E%0A%3C%2Fhead%3E%3Cbody%3E%3Cdiv class%3D%22transcription%22%3ENo translation available for this image.%3C%2Fdiv%3E%3C%2Fbody%3E%3C%2Fhtml%3E';
+        $('#translationframe').contents().find('head').html(transCss);
+        $('#translationframe').contents().find('body').html("No translation available for this image.");
     }
 
     // set all diplomatic transcriptions (all transcriptions on one page)
     var url = data.allTranscriptionDiplomaticURL;
     if (typeof url != 'undefined') {
-        document.getElementById('transcriptiondiploframe').src = context.services + url;
+        $('#transcriptiondiploframe').removeAttr('srcdoc');
+        $('#transcriptiondiploframe').attr('src', new URL(url, context.services));
     }
 
 }


### PR DESCRIPTION
This PR partly fixes a bug that prevents the browser back button from functioning as intended when paging through items viewed in Chrome browser.

The bug is triggered when viewing and paging through a collection item with Chrome browser. When paging through an item (with the JavaScript page turning buttons) and then pressing the browser back button, nothing seems to happen. In Firefox, the browser correctly navigates to the webpage before the collection item.

This is behaviour specific to Chrome (see https://bugs.chromium.org/p/chromium/issues/detail?id=172859) . In Chrome, the loading of `<iframe>`s that display transcription/translation content causes extra entries to be pushed onto the window history. This fills up the window history with 2 new entries every time an item page is turned. Thus, after a few turns of the item page, it is necessary to press the back button (2 x page turns + 1) to get back to the webpage before the collection item.

**Full fix for items with no transcription/translation content**

There's no need to do a whole iframe load in order to display a simple "Nothing to see here" message. This is now injected with JavaScript into a pre-existing `srcdoc` in the `<iframe>`. This prevents Chrome from pushing new history states in these cases.

**Partial fix for items with transcription/translation**

The obvious solution to injecting content without a page load (ajax) won't work because of browser cross-origin restrictions. But as most items don't have both transcription _and_ translation, we can at least reduce the number of history pushes by 1 for each page turn.

