### PR TITLE
Enable broswer back button to scrolls back through viewing history of…

### DIFF
--- a/src/js/pages/document.js
+++ b/src/js/pages/document.js
@@ -966,7 +966,6 @@ function setTranscriptionPage(data, pagenum) {
         let targetIframe = $('#' + iframeData[key].id);
         let newIframe = targetIframe.clone();
         newIframe.attr('src', iframeData[key].src);
-        newIframe.attr('data-test', iframeData[key].src);
         targetIframe.replaceWith(newIframe);
     }
 }


### PR DESCRIPTION
Enable to browser's back button to work as expected (i.e. updating transcription/translation and image as it goes back through the browser history).
This PR has an associated one in cudl-viewer.