### PR TITLE
Minimise fade effect on the slideshow

### DIFF
--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -741,18 +741,18 @@ img {vertical-align: middle;}
 /* Fading animation */
 .fade {
   -webkit-animation-name: fade;
-  -webkit-animation-duration: 1.5s;
+  -webkit-animation-duration: 1s;
   animation-name: fade;
-  animation-duration: 1.5s;
+  animation-duration: 1s;
 }
 
 @-webkit-keyframes fade {
-  from {opacity: .4}
-  to {opacity: 1}
+  from {opacity: 1}
+  to {opacity: 0.95}
 }
 
 @keyframes fade {
-  from {opacity: .4}
+  from {opacity: .95}
   to {opacity: 1}
 }
 


### PR DESCRIPTION
The transition between panels in the slideshow produces a jarring flash of white. These changes are not an ideal solution since they largely minimise the transition animation to the point that it isn't really discernible. An ideal solution would likely involve having separate animation effects for fade out/fade in.