### PR TITLE
Cudl 495 496 tweaks

### DIFF
--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -1104,8 +1104,9 @@ img {vertical-align: middle;}
     display: inline-flex;
     padding: 0;
     width: 100%;
-    font-size: 1.25rem;
-    line-height:1.5
+    font-size: 1.5rem;
+    line-height:1.5;
+    text-align: center;
 }
 
 .xl-button-caption a, .xl-button-caption a:link, .xl-button-caption a:visited,.xl-button-caption a:hover, .xl-button-caption a:focus, .xl-button-caption a:active {

--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -1104,6 +1104,8 @@ img {vertical-align: middle;}
     display: inline-flex;
     padding: 0;
     width: 100%;
+    font-size: 1.25rem;
+    line-height:1.5
 }
 
 .xl-button-caption a, .xl-button-caption a:link, .xl-button-caption a:visited,.xl-button-caption a:hover, .xl-button-caption a:focus, .xl-button-caption a:active {

--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -347,6 +347,7 @@ h2, h3, h4, h5, h6 {
     padding: 0 0 0 40px;
     background-size: 35.2px 35.2px !important;
 }
+
 .icon.icon-menu {
     background-image: url(/img/interface/noun_menu_black.svg);
 }
@@ -1097,12 +1098,13 @@ img {vertical-align: middle;}
     background-color: #106470;
     color: #fff;
     display: inline-flex;
-    padding: 1rem !important;
+    padding: 0;
     width: 100%;
 }
 
-.xl-button-caption a:visited {
+.xl-button-caption a, .xl-button-caption a:link, .xl-button-caption a:visited,.xl-button-caption a:hover, .xl-button-caption a:focus, .xl-button-caption a:active {
     color: #fff;
+    text-decoration:none;
 }
 
 .xl-button-caption:hover {
@@ -1115,10 +1117,6 @@ img {vertical-align: middle;}
     padding: 30px 0 15px 0;
 }
 
-.xl-button-container a {
-    width: 100%;
-}
-
 .xl-button-left  {
     max-width: 100%;
     width: 100%;
@@ -1129,6 +1127,12 @@ img {vertical-align: middle;}
     max-width: 100%;
     width: 100%;
     display: inline-flex;
+}
+
+.xl-button-left a, .xl-button-right a {
+    display: inline-block;
+    width: 100%;
+    padding: 1rem;
 }
 
 .xl-button-padding {

--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -388,6 +388,10 @@ button {
     font-size: inherit;
 }
 
+.nav-right-items div.search {
+    display: inline-block;
+}
+
 /* Hidden menu */
 
 .dropbtn {


### PR DESCRIPTION
Various CSS tweaks to ensure that the primary action buttons on the homepage look and perform as one would expect. This branch also resolves an issue that caused the pink border around the search icon to be obscured by the main menu's hamburger icon.

Related to cudl-view PR (https://github.com/cambridge-collection/cudl-viewer/pull/29)