### PR TITLE
Fix outline on a:focus and simplify homepage css

### DIFF
--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -842,18 +842,29 @@ img {vertical-align: middle;}
 
 .tile-container{
     display: flex;
-  flex-wrap: wrap;
+    flex-wrap: wrap;
     padding-bottom: 10px;
 }
-.tile {
+
+.tile, .article {
     position: relative;
     flex: 33.3%;
     max-width: 33.3%;
-    float: left;
   }
-.tile:hover .tile-caption a {
+
+.tile-caption {
     background-color: #E5007D;
 }
+
+.tile a, .tile-container .article a {
+    display: block;
+    width: 100%;
+}
+
+.tile a:focus {
+    outline-offset: -6px;
+}
+
   @media screen and (max-width: 800px) {
     .tile {
       flex: 50%;
@@ -875,29 +886,31 @@ img {vertical-align: middle;}
     height: auto;
   }
 
-  .tile-caption-container{
+.tile-caption-container {
+    position: absolute;
+    bottom: 80px;
+    left: 0;
+    right: 0;
+    margin-left: 0;
+    width: 25rem;
+}
 
-        position: absolute;
-        bottom: 80px;
-        left: 0;
-        right: 0;
-        margin-left: 0;
-        width: 25rem;
-
-
-  }
-
-  .tile-caption a {
+.tile-caption {
     background-color: #000;
     color: #fff;
-      padding: 0.6rem;
-      text-align: center;
+    padding: 0.6rem;
+    text-align: center;
     font-size: 1.25rem;
     text-decoration: none;
+}
 
-  }
-
-  .tile-caption a:hover{
+  .tile:hover .tile-caption, .tile a:focus .tile-caption {
+/* Jennie, , .tile a:focus .tile-caption could be removed.
+   It replicates the hover behaviour on the captions during
+   a focus state. I think it looks nice, but it's also inconsistent
+   with how focus works everywhere else. Because the tiles are themselves
+   different, I'm not sure whether to keep it or not.
+ */
       background-color: #E5007D;
   }
 
@@ -912,6 +925,11 @@ img {vertical-align: middle;}
       flex: 66%;
       max-width: 66%;
       float: left;
+  }
+
+  .watch-feature iframe {
+      width: 100%;
+      border: none;
   }
 
   .watch-list{
@@ -952,7 +970,6 @@ img {vertical-align: middle;}
     position: relative;
     flex: 33.3%;
     max-width: 33.3%;
-    float: left;
     padding: 10px;
   }
 
@@ -960,10 +977,11 @@ img {vertical-align: middle;}
     font-size: 1.5rem;
     margin-top: 1rem;
 }
-.article h2 a {
+.article a, .article:hover a p {
     color: #000000;
+    text-decoration: none;
 }
-.article:hover h2 a {
+.article:hover a h2 {
     text-decoration: underline;
     color: #E5007D;
 }
@@ -989,34 +1007,35 @@ img {vertical-align: middle;}
 
 /* Social media icons */
 
+.follow_us a {
+    display: inline-block;
+    margin-right: 0.75rem;
+}
+
 .icon {
+    display: inline-block;
     background-position: left;
     background-repeat: no-repeat;
     background-size: 2.2rem 2.2rem !important;
-    padding: 0 0 0 5rem;
+    padding: 0;
+    height: 2.2rem;
+    width: 2.2rem;
 }
 
 .icon-facebook {
     background-image: url(https://www.cam.ac.uk/sites/www.cam.ac.uk/themes/fresh/images/interface/icons/facebook_black.svg);
-    padding: 1.5rem;
 }
 
 .icon-instagram {
     background-image: url(https://www.cam.ac.uk/sites/www.cam.ac.uk/themes/fresh/images/interface/icons/instagram_black.svg);
-    padding: 1.5rem;
-
 }
 
 .icon-twitter {
     background-image: url(https://www.cam.ac.uk/sites/www.cam.ac.uk/themes/fresh/images/interface/icons/twitter_blue.svg);
-    padding: 1.5rem;
-
 }
 
 .icon-youtube {
     background-image: url(https://www.cam.ac.uk/sites/www.cam.ac.uk/themes/fresh/images/interface/icons/youtube_black.svg);
-    padding: 1.5rem;
-
 }
 
 


### PR DESCRIPTION
The a:focus outline should work on the tiles/articles now.

There is one behaviour that I'm unsure of whether to keep. I've made a:focus on the tiles change the colour of the caption box to match the change on a:hover. It looks nice, but it isn't how a:focus works on anything else on the site. I'm not sure whether that means we should deleted the selection (identified with a comment) or whether we accept that this deviation in behaviour is acceptable because tiles themselves are exceptional.

I also refactored the homepage css (and homepage html) to simplify things a bit.

 For these changes to work, you'll need need new html. I changed not only the coding of the tiles, but also fixed every validation issue in the file.

I've attached two zips: index-release.zip contains a version you can dump on your local drive for testing. If all is well with the release, drop the file in index-source.zip into dev-cudl-data-source.
[index-source.zip](https://github.com/cambridge-collection/cudl-viewer-ui/files/11573510/index-source.zip)
[index-release.zip](https://github.com/cambridge-collection/cudl-viewer-ui/files/11573514/index-release.zip)
