### PR TITLE
Make colours match CAM cookiebar

### DIFF
--- a/src/css/cudl.css
+++ b/src/css/cudl.css
@@ -1340,3 +1340,11 @@ img {
         scroll-snap-margin-top: 56px; /* iOS 11 and older */
     }
 }
+
+/* Custom Cookie banner style */
+.cc-compliance a.cc-btn.cc-deny {
+    /* border-color: #f0f; */
+    border-style: solid;
+    border-width: 2px;
+    border-color: #fcfcfc;
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -461,6 +461,7 @@ ol#virtual_collections_carousel li {
     min-height: 190px;
     max-width: 500px;
     float:left;
+    margin: 5px; /*space needed for perimetral hover pink highlighting */
 }
 
 .virtual_collections_carousel_image_box {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,12 +1,12 @@
 @import "cudl-editor.css";
 /* @import "recall-slider.css"; */
 @import "column-layouts.css";
-@import "project-light-legacy.css";
 @import "font-awesome/css/font-awesome.min.css";
 @import 'paginationjs/dist/pagination.css';
 @import "cookieconsent/build/cookieconsent.min.css";
 @import "bootstrap/dist/css/bootstrap.min.css";
 @import "cudl.css";
+@import "project-light-legacy.css";
 
 
 

--- a/src/js/cookie-banner-config.js
+++ b/src/js/cookie-banner-config.js
@@ -8,12 +8,12 @@ window.addEventListener('load', function(){
         theme: "classic",
         palette: {
             popup: {
-                background: "#ccc",
-                text: "#444"
+                background: "#151515",
+                text: "#fcfcfc"
             },
             button: {
-                background: "#8c6",
-                text: "#fff"
+                background: "#fcfcfc",
+                text: "#151515"
             }
         },
         content: {


### PR DESCRIPTION
Changes the colours of the cookiebar to match the CAM cookie notice.

If changes to the text are required, they can be made by altering the message (the base message for the cookie banner), link (the text of the hyperlink to the page explaining how we use cookies) and href (the URL to the cookie explanation page) values in cookie-banner-config.js.

The necessary changes in the cudl-viewer were already merged into the bootstrap5 branch with https://github.com/cambridge-collection/cudl-viewer/pull/46