### PR TITLE
feat(collapse): reinstate collapse toggling on collection pages

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1143,4 +1143,7 @@ div.pagination {
     bottom: -3rem;
 }
 
+.collapse table {
+    margin-bottom: 1rem;
+}
 /* end of TEST classes for Bootstrap 5.3 */

--- a/src/js/pages/collection-organisation.js
+++ b/src/js/pages/collection-organisation.js
@@ -94,4 +94,11 @@ $(function() {
         $(document.body).attr('data-context', JSON.stringify(context));
     }
 
+    $( document ).ready(function() {
+        $('*[data-toggle="collapse"]').on( "click", function() {
+            let href_attr = $(this).attr('href');
+            $(href_attr).toggle("slow");
+        } );
+    });
+
 });


### PR DESCRIPTION
We lost the ability to have collapsable content following our migration from Project Light.
This feature has now been restored.

The code works on the following snippets. The clickable header is wrapped in an ```<a/>``` that has a ```data-toggle="collapse"``` and a ```href``` attr that points to the id of the content that is to be shown/hidden.

```
<p><b><a data-toggle="collapse" href="#content_id">+ Clickable header</a></b></p>
<div class="collapse" id="content_id"> <!-- content goes here --></div>
```