### PR TITLE
Prettify snippets

### DIFF
--- a/src/css/advancedsearch.css
+++ b/src/css/advancedsearch.css
@@ -107,6 +107,46 @@
     padding-left: .5em;
 }
 
+div.collections_carousel_item ul.snippets {
+    margin: 1em 0 0 0;
+    padding: 0;
+    font-size: 0.95em
+}
+div.collections_carousel_item ul.snippets li.snippet::before {
+    content: none;
+    padding-left: 0
+}
+div.collections_carousel_item ul.snippets li.snippet {
+    margin: 0 0 0.5em 0;
+    padding: 0 0 0 0;
+    list-style-type: disc;
+    line-height: 1.25em;
+    text-indent: -0.5em;
+}
+div.collections_carousel_item ul.snippets li.snippet span {
+    display: inline
+}
+div.collections_carousel_item ul.snippets li.snippet span * {
+    display: inline;
+}
+
+div.collections_carousel_item ul.snippets li.snippet span br { display:none;}
+div.collections_carousel_item ul.snippets li.snippet span p,
+div.collections_carousel_item ul.snippets li.snippet span div,
+div.collections_carousel_item ul.snippets li.snippet span ul,
+div.collections_carousel_item ul.snippets li.snippet span li,
+div.collections_carousel_item ul.snippets li.snippet span ol,
+div.collections_carousel_item ul.snippets li.snippet span table,
+div.collections_carousel_item ul.snippets li.snippet span tr,
+div.collections_carousel_item ul.snippets li.snippet span th,
+div.collections_carousel_item ul.snippets li.snippet span td {
+    margin-right: 0.2em
+}
+
+div.collections_carousel_item ul.snippets li.snippet em.match {
+    color: red
+}
+
 /* pagination */
 .pagination {
     display: block;

--- a/src/js/pages/advanced-search-results.js
+++ b/src/js/pages/advanced-search-results.js
@@ -13,8 +13,7 @@ import 'paginationjs';
 import {toggleDiv} from "../cudl";
 
 function styleSnippet(s) {
-    s = s.replace(/<b>/g, "<span class=\"campl-search-term\">");
-    s = s.replace(/<\/b>/g, "</span>");
+    s = s.replace(/(^[^<>]+>|<[^>]+$)/g, "");
     return s;
 }
 

--- a/src/js/pages/advanced-search-results.js
+++ b/src/js/pages/advanced-search-results.js
@@ -229,12 +229,12 @@ function renderResult(result) {
                                     "Page: ", document.createTextNode(result.startPageLabel), ")"
                                 )
                         ),
-                    document.createTextNode(item.abstractShort),
-                    $("<br><br>"),
-                    $("<ul>")
+                    $("<div>").append(
+                    document.createTextNode(item.abstractShort)),
+                    $("<ul class=\"snippets\">")
                         .append(
                             result.snippets.filter(Boolean).map(function(snippet) {
-                                return $("<li>")
+                                return $("<li class=\"snippet\">")
                                     .append(
                                         $("<span>").html(styleSnippet(snippet))
                                     )[0];


### PR DESCRIPTION
- Added classnames to snippet elems
- removed br spacers and replaced with css.
- added containing div for abstract so it's not free-floating text (which interfered with css)
- Added regex that should remove partial html elements from snippets (ie. `em>` or `</e`

Left original declarations for `.collections_carousel_text ul`, `.collections_carousel_text ul li` and `.collections_carousel_text ul li:before` in advancedsearch.css since I suspect that might be used by other content included in the search result items. I improved look/replicated behaviour within the css with classnames that I added.