### PR TITLE
fix: reset all fields in searchform after returning to form to refine it

### DIFF
--- a/src/js/pages/advancedsearch.js
+++ b/src/js/pages/advancedsearch.js
@@ -39,3 +39,11 @@ $(() => {
     // not in place when the width of the slider is calculated.
     //defer(createVariableRecallSlider);
 });
+$(() => {
+    $("#searchForm button[type='reset']").click(function(){
+        var form = $(this).parents('form:first');
+        form.find("*[value]").attr('value', '');
+        form.find("*[selected]").removeAttr('selected');
+    });
+
+});


### PR DESCRIPTION
Perform a search using a keyword and any advanced field and click on change query and return to the form.

If you click the reset button, it won’t clear the fields you previously defined. This is because the input elems for those fields stores their value within the value attribute. The problem is that the default reset action actually only restores input values to the contents of their value attribute. That means we’ll need a custom javascript handler to reset all the form contents. 